### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/weather_underground_api.dart
+++ b/lib/weather_underground_api.dart
@@ -233,7 +233,7 @@ class WeatherUnderground {
         return request.close();
       })
       .then((HttpClientResponse response) {
-        response.transform(new StringDecoder()).toList().then((data) {          
+        new StringDecoder().bind(response).toList().then((data) {          
           String body = data.join('');
           var parsedList = parse(body);
           completer.complete(parsedList['RESULTS']);
@@ -254,7 +254,7 @@ class WeatherUnderground {
         return request.close();
       })
       .then((HttpClientResponse response) {
-        response.transform(new StringDecoder()).toList().then((data) {          
+        new StringDecoder().bind(response).toList().then((data) {          
           String body = data.join('');
           var parsedList = parse(body);
           if(parsedList['response']['error'] != null) {


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
